### PR TITLE
Assertion fixes

### DIFF
--- a/definitions/core/assertions/assertions_sessions_validity.sqlx
+++ b/definitions/core/assertions/assertions_sessions_validity.sqlx
@@ -42,7 +42,7 @@ pre_operations {
       ${ref("ga4_sessions")}
     WHERE
       session_date >= DATE_SUB( CURRENT_DATE(), INTERVAL 3 day )
-      AND (landing_page.landing_page_location IS NULL
+      AND ((landing_page.landing_page_location IS NULL AND app_info.id IS NULL)
         OR user_pseudo_id IS NULL
         OR session_id IS NULL
         OR session_date IS NULL

--- a/definitions/core/assertions/assertions_tables_timeliness.sqlx
+++ b/definitions/core/assertions/assertions_tables_timeliness.sqlx
@@ -70,7 +70,7 @@ pre_operations {
       FROM
         ${ref("events_*")}
       WHERE
-        CONTAINS_SUBSTR(_TABLE_SUFFIX, 'intraday') IS FALSE) );
+        CONTAINS_SUBSTR(_TABLE_SUFFIX, 'intraday') IS FALSE AND CONTAINS_SUBSTR(_TABLE_SUFFIX, 'fresh') IS FALSE ) );
   IF
     check > expectations THEN
   SET


### PR DESCRIPTION
I had installed GA4Dataform for 7 different GA4 properties and I was commonly seeing errors with assertions due to session valadility and timeliness.  I tracked it down to "fresh" tables and APP sessions.  

I tested these changes by overriding the CORE assertion file and creating my own CUSTOM version where I installed GA4 Data Form - fixed and no issues were the result.  

Therefore, I decide to share my fixes so that hopefully that make it into the CORE product.